### PR TITLE
Corregido para que compilara

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 ALL= generador main
 ALL:$(ALL)
-PHONY: clean
-CFLAGS= -g
+PHONY:clean
+CFLAGS= -g 
+CPPFLAGS=-std=c++11
 LDFLAGS=-lpthread
 
 clean:

--- a/main.cpp
+++ b/main.cpp
@@ -13,6 +13,9 @@
 #include <string>
 #include "pthread.h"
 
+#include <cstring>
+
+
 #define STACK 1000
 #define NUM_THREADS 4
 


### PR DESCRIPTION
No me compilaba, y ahora aunque compila, no funciona, por ejemplo:

```
$ ./generador -s 1 -a 0 -b 10 -c 10 | ./main
3
6
7
5
3
5
6
2
9
1

terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoi
Aborted
$
```
